### PR TITLE
feat: Implement auto-join functionality for meetings

### DIFF
--- a/app/api/v1/endpoints/users.py
+++ b/app/api/v1/endpoints/users.py
@@ -6,8 +6,8 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
 
-from app.core.database import get_db
-from app.schemas.user import UserResponse, UserUpdate
+from app.core.database import get_db, SessionLocal
+from app.schemas.user import UserResponse, UserUpdate, DigitalTwinProfileUpdate, DigitalTwinProfileResponse
 from app.services.auth import get_current_user_bearer
 from app.services.user import get_user_profile, update_user_profile
 from app.models.user import User
@@ -29,3 +29,97 @@ async def update_current_user_profile(
 ):
     """Update current user profile"""
     return await update_user_profile(db, current_user.id, user_update)
+
+
+# Digital Twin Profile Management Endpoints
+
+@router.get("/digital-twin/profile", response_model=DigitalTwinProfileResponse)
+async def get_digital_twin_profile(
+    current_user: User = Depends(get_current_user_bearer),
+    db: Session = Depends(get_db)
+):
+    """Get digital twin profile settings"""
+    try:
+        user = db.query(User).filter(User.id == current_user.id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        
+        return DigitalTwinProfileResponse(
+            user_id=user.id,
+            bot_name=user.bot_name,
+            profile_picture=user.profile_picture,
+            full_name=user.full_name,
+            email=user.email
+        )
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error getting digital twin profile: {str(e)}")
+
+
+@router.put("/digital-twin/profile", response_model=DigitalTwinProfileResponse)
+async def update_digital_twin_profile(
+    profile_update: DigitalTwinProfileUpdate,
+    current_user: User = Depends(get_current_user_bearer),
+    db: Session = Depends(get_db)
+):
+    """Update digital twin profile settings (name and profile picture)"""
+    try:
+        user = db.query(User).filter(User.id == current_user.id).first()
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        
+        # Update bot name if provided
+        if profile_update.bot_name is not None:
+            user.bot_name = profile_update.bot_name
+        
+        # Update profile picture if provided
+        if profile_update.profile_picture is not None:
+            user.profile_picture = profile_update.profile_picture
+        
+        db.commit()
+        db.refresh(user)
+        
+        return DigitalTwinProfileResponse(
+            user_id=user.id,
+            bot_name=user.bot_name,
+            profile_picture=user.profile_picture,
+            full_name=user.full_name,
+            email=user.email
+        )
+        
+    except Exception as e:
+        db.rollback()
+        raise HTTPException(status_code=500, detail=f"Error updating digital twin profile: {str(e)}")
+
+
+@router.get("/digital-twin/preview")
+async def preview_digital_twin(
+    current_user: User = Depends(get_current_user_bearer),
+    db: Session = Depends(get_db)
+):
+    """Get a preview of how the digital twin will appear in meetings"""
+    try:
+        user = db.query(User).filter(User.id == current_user.id).first()
+        
+        if not user:
+            raise HTTPException(status_code=404, detail="User not found")
+        
+        # Show how the bot will appear
+        display_name = user.bot_name or "Digital Twin Bot"
+        
+        return {
+            "success": True,
+            "preview": {
+                "display_name": display_name,
+                "profile_picture": user.profile_picture,
+                "will_appear_as": f"Meeting participant: {display_name}",
+                "settings": {
+                    "custom_name": user.bot_name is not None,
+                    "custom_picture": user.profile_picture is not None,
+                    "fallback_name": "Digital Twin Bot" if not user.bot_name else None
+                }
+            }
+        }
+        
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Error generating preview: {str(e)}")

--- a/app/core/celery.py
+++ b/app/core/celery.py
@@ -16,6 +16,9 @@ celery_app = Celery(
     ]
 )
 
+# Import beat schedule
+from app.services.celery_beat_config import beat_schedule
+
 celery_app.conf.update(
     task_serializer="json",
     accept_content=["json"],
@@ -25,4 +28,6 @@ celery_app.conf.update(
     task_track_started=True,
     task_time_limit=30 * 60,  # 30 minutes
     task_soft_time_limit=25 * 60,  # 25 minutes
+    beat_schedule=beat_schedule,  # Add beat schedule
+    beat_scheduler='django_celery_beat.schedulers:DatabaseScheduler',  # Use database scheduler if available
 )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
     
     # Recall AI
     RECALL_API_KEY: str = ""
-    RECALL_BASE_URL: str = ""
+    RECALL_BASE_URL: str = "https://us-west-2.recall.ai/api/v1"
     
     # Voice Settings
     VOICE_MODEL_PATH: str = "models/voice/"
@@ -60,6 +60,10 @@ class Settings(BaseSettings):
     VECTOR_DB_PATH: str = "data/vectordb/"
     CHUNK_SIZE: int = 1000
     CHUNK_OVERLAP: int = 200
+    
+    # Auto-join Settings
+    AUTO_JOIN_ADVANCE_MINUTES: int = 2  # Join meeting 2 minutes before start time
+    AUTO_JOIN_CHECK_INTERVAL: int = 30  # Check for meetings every 30 seconds
     
     model_config = ConfigDict(env_file=".env")
 

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,10 @@ AI-powered meeting automation system with Google OAuth
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
+from fastapi.responses import FileResponse
 from contextlib import asynccontextmanager
+import os
 
 from app.core.config import settings
 from app.core.database import init_db
@@ -67,6 +70,9 @@ app.add_middleware(
 # Include API routes
 app.include_router(api_router, prefix="/api/v1")
 
+# Mount static files
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
 
 @app.get("/")
 async def root():
@@ -76,8 +82,15 @@ async def root():
         "version": "1.0.0",
         "auth": "Google OAuth enabled",
         "docs": "/docs",
-        "openapi": "/openapi.json"
+        "openapi": "/openapi.json",
+        "digital_twin_profile": "/digital-twin-profile"
     }
+
+
+@app.get("/digital-twin-profile")
+async def serve_digital_twin_profile():
+    """Serve the digital twin profile management page"""
+    return FileResponse("static/digital_twin_profile.html")
 
 
 @app.get("/health")

--- a/app/schemas/meeting.py
+++ b/app/schemas/meeting.py
@@ -69,6 +69,7 @@ class MeetingJoinRequest(BaseModel):
     meeting_url: str
     recording_config: Optional[Dict[str, Any]] = None
     bot_name: Optional[str] = None
+    profile_picture: Optional[str] = None  # URL for bot avatar
     enable_realtime_processing: Optional[bool] = False
 
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -19,3 +19,21 @@ class UserResponse(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+class DigitalTwinProfileUpdate(BaseModel):
+    """Schema for updating digital twin profile settings"""
+    bot_name: Optional[str] = None
+    profile_picture: Optional[str] = None  # URL or base64 string
+
+
+class DigitalTwinProfileResponse(BaseModel):
+    """Schema for digital twin profile response"""
+    user_id: int
+    bot_name: Optional[str] = None
+    profile_picture: Optional[str] = None
+    full_name: Optional[str] = None
+    email: str
+
+    class Config:
+        from_attributes = True

--- a/app/services/auto_join_manager.py
+++ b/app/services/auto_join_manager.py
@@ -1,0 +1,121 @@
+"""
+Auto-join service manager
+Handles starting and monitoring the Celery worker and beat scheduler for auto-join functionality
+"""
+
+import subprocess
+import logging
+import os
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+class AutoJoinManager:
+    def __init__(self):
+        self.worker_process = None
+        self.beat_process = None
+        self.project_root = Path(__file__).parent.parent.parent
+        
+    def start_worker(self):
+        """Start Celery worker"""
+        try:
+            cmd = [
+                sys.executable, "-m", "celery", 
+                "-A", "app.core.celery:celery_app", 
+                "worker", 
+                "--loglevel=info",
+                "--concurrency=2"
+            ]
+            
+            self.worker_process = subprocess.Popen(
+                cmd,
+                cwd=self.project_root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            
+            logger.info(f"Celery worker started with PID: {self.worker_process.pid}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to start Celery worker: {str(e)}")
+            return False
+    
+    def start_beat(self):
+        """Start Celery beat scheduler"""
+        try:
+            cmd = [
+                sys.executable, "-m", "celery",
+                "-A", "app.core.celery:celery_app",
+                "beat",
+                "--loglevel=info"
+            ]
+            
+            self.beat_process = subprocess.Popen(
+                cmd,
+                cwd=self.project_root,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            
+            logger.info(f"Celery beat started with PID: {self.beat_process.pid}")
+            return True
+            
+        except Exception as e:
+            logger.error(f"Failed to start Celery beat: {str(e)}")
+            return False
+    
+    def start_all(self):
+        """Start both worker and beat"""
+        worker_started = self.start_worker()
+        beat_started = self.start_beat()
+        
+        return worker_started and beat_started
+    
+    def stop_worker(self):
+        """Stop Celery worker"""
+        if self.worker_process:
+            try:
+                self.worker_process.terminate()
+                self.worker_process.wait(timeout=10)
+                logger.info("Celery worker stopped")
+                return True
+            except Exception as e:
+                logger.error(f"Failed to stop Celery worker: {str(e)}")
+                return False
+        return True
+    
+    def stop_beat(self):
+        """Stop Celery beat"""
+        if self.beat_process:
+            try:
+                self.beat_process.terminate()
+                self.beat_process.wait(timeout=10)
+                logger.info("Celery beat stopped")
+                return True
+            except Exception as e:
+                logger.error(f"Failed to stop Celery beat: {str(e)}")
+                return False
+        return True
+    
+    def stop_all(self):
+        """Stop both worker and beat"""
+        worker_stopped = self.stop_worker()
+        beat_stopped = self.stop_beat()
+        
+        return worker_stopped and beat_stopped
+    
+    def is_running(self):
+        """Check if services are running"""
+        worker_running = self.worker_process and self.worker_process.poll() is None
+        beat_running = self.beat_process and self.beat_process.poll() is None
+        
+        return {
+            "worker": worker_running,
+            "beat": beat_running,
+            "both": worker_running and beat_running
+        }
+
+# Global manager instance
+auto_join_manager = AutoJoinManager()

--- a/app/services/calendar.py
+++ b/app/services/calendar.py
@@ -345,6 +345,10 @@ class GoogleCalendarService:
                         logger.info(f"Updated existing meeting {existing_meeting.id} for event {event_id}")
                     else:
                         # Create new meeting
+                        # Enable auto-join if user has backend tasks enabled
+                        auto_join_enabled = user.enable_backend_tasks if user.enable_backend_tasks is not None else True
+                        digital_twin_id = user.id if auto_join_enabled else None
+                        
                         new_meeting = Meeting(
                             user_id=user.id,
                             title=summary,
@@ -358,6 +362,8 @@ class GoogleCalendarService:
                             status="scheduled",
                             participants=participants,
                             calendar_event_id=event_id,
+                            auto_join=auto_join_enabled,  # Enable auto-join based on user preference
+                            digital_twin_id=digital_twin_id,  # Set to user_id if auto-join enabled
                             created_at=datetime.utcnow()
                         )
                         db.add(new_meeting)

--- a/app/services/celery_beat_config.py
+++ b/app/services/celery_beat_config.py
@@ -1,0 +1,27 @@
+"""
+Celery Beat configuration for scheduled tasks
+"""
+
+from celery.schedules import crontab
+from app.core.config import settings
+
+# Celery Beat schedule
+beat_schedule = {
+    'auto-join-meetings': {
+        'task': 'app.services.meeting_automation.auto_join_scheduler',
+        'schedule': 30.0,  # Run every 30 seconds
+        'options': {
+            'expires': 15,  # Task expires after 15 seconds if not executed
+        }
+    },
+    'cleanup-old-meetings': {
+        'task': 'app.services.meeting_automation.cleanup_old_meetings',
+        'schedule': crontab(minute=0, hour=2),  # Run daily at 2 AM
+    },
+}
+
+# Celery Beat settings
+beat_settings = {
+    'beat_schedule': beat_schedule,
+    'timezone': 'UTC',
+}

--- a/app/services/meeting.py
+++ b/app/services/meeting.py
@@ -14,6 +14,12 @@ from app.services.meeting_automation import schedule_meeting_join
 
 async def create_meeting(db: Session, meeting: MeetingCreate, user_id: int) -> Meeting:
     """Create a new meeting"""
+    
+    # If auto_join is enabled and no digital_twin_id is provided, use user_id
+    digital_twin_id = meeting.digital_twin_id
+    if meeting.auto_join and not digital_twin_id:
+        digital_twin_id = user_id  # Each user has their own digital twin with same ID
+    
     db_meeting = Meeting(
         title=meeting.title,
         description=meeting.description,
@@ -22,7 +28,7 @@ async def create_meeting(db: Session, meeting: MeetingCreate, user_id: int) -> M
         scheduled_time=meeting.scheduled_time,
         duration_minutes=meeting.duration_minutes or 60,
         user_id=user_id,
-        digital_twin_id=meeting.digital_twin_id,
+        digital_twin_id=digital_twin_id,
         auto_join=meeting.auto_join,
         status="scheduled"
     )

--- a/app/services/meeting_automation.py
+++ b/app/services/meeting_automation.py
@@ -3,17 +3,183 @@ Meeting automation service for handling digital twin meeting participation
 """
 
 from celery import Celery
-from datetime import datetime
-from typing import Optional
+from datetime import datetime, timedelta
+from typing import Optional, List
 import requests
 import logging
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
 
 from app.core.config import settings
+from app.core.database import SessionLocal
+from app.models.meeting import Meeting
+from app.models.bot import Bot
+from app.models.user import User
+from app.schemas.meeting import MeetingJoinRequest
+from app.services.recall_service import recall_service
 
 logger = logging.getLogger(__name__)
 
 # Initialize Celery (this would typically be configured elsewhere)
 celery_app = Celery('meeting_automation')
+
+
+@celery_app.task
+def auto_join_scheduler():
+    """
+    Periodic task to check for meetings that need auto-joining
+    This should be scheduled to run every 30 seconds using Celery Beat
+    """
+    logger.info("Running auto-join scheduler...")
+    
+    try:
+        db = SessionLocal()
+        
+        # Calculate the time window for auto-joining
+        now = datetime.utcnow()
+        join_window_start = now
+        join_window_end = now + timedelta(minutes=settings.AUTO_JOIN_ADVANCE_MINUTES)
+        
+        # Find meetings that need auto-joining
+        meetings_to_join = db.query(Meeting).filter(
+            and_(
+                Meeting.auto_join == True,
+                Meeting.status == "scheduled",
+                Meeting.scheduled_time >= join_window_start,
+                Meeting.scheduled_time <= join_window_end,
+                Meeting.digital_twin_id.isnot(None)
+            )
+        ).all()
+        
+        logger.info(f"Found {len(meetings_to_join)} meetings to auto-join")
+        
+        for meeting in meetings_to_join:
+            try:
+                # Update meeting status to prevent duplicate joins
+                meeting.status = "joining"
+                db.commit()
+                
+                # Trigger the join meeting task
+                join_meeting_auto.delay(
+                    meeting.id,
+                    meeting.digital_twin_id,
+                    meeting.meeting_url,
+                    meeting.platform,
+                    meeting.user_id
+                )
+                
+                logger.info(f"Scheduled auto-join for meeting {meeting.id} ({meeting.title})")
+                
+            except Exception as e:
+                logger.error(f"Failed to schedule auto-join for meeting {meeting.id}: {str(e)}")
+                # Reset status if scheduling failed
+                meeting.status = "scheduled"
+                db.commit()
+        
+        db.close()
+        
+    except Exception as e:
+        logger.error(f"Auto-join scheduler error: {str(e)}")
+
+
+@celery_app.task
+def join_meeting_auto(meeting_id: int, twin_id: int, meeting_url: str, platform: str, user_id: int):
+    """
+    Automatically join a meeting with the digital twin using Recall AI
+    """
+    import asyncio
+    
+    async def _join_meeting_async():
+        logger.info(f"Auto-joining meeting {meeting_id} with twin {twin_id}")
+        
+        try:
+            db = SessionLocal()
+            
+            # Get the meeting details
+            meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+            if not meeting:
+                logger.error(f"Meeting {meeting_id} not found")
+                return {"status": "failed", "error": "Meeting not found"}
+            
+            # Get user details for bot naming
+            user = db.query(User).filter(User.id == user_id).first()
+            bot_name = f"{user.bot_name if user and user.bot_name else 'Digital Twin'}"
+            
+            # Create the join request
+            join_request = MeetingJoinRequest(
+                meeting_url=meeting_url,
+                bot_name=bot_name,
+                enable_realtime_processing=True
+            )
+            
+            # Join the meeting using Recall AI
+            response = await recall_service.join_meeting(join_request)
+            
+            if response.success and response.bot_id:
+                # Update meeting status
+                meeting.status = "in_progress"
+                
+                # Create or update bot record
+                existing_bot = db.query(Bot).filter(Bot.bot_id == response.bot_id).first()
+                if not existing_bot:
+                    new_bot = Bot(
+                        bot_id=response.bot_id,
+                        user_id=user_id,
+                        bot_name=bot_name,
+                        platform=platform,
+                        meeting_id=meeting_id
+                    )
+                    db.add(new_bot)
+                else:
+                    existing_bot.meeting_id = meeting_id
+                    existing_bot.platform = platform
+                
+                db.commit()
+                
+                logger.info(f"Successfully auto-joined meeting {meeting_id} with bot {response.bot_id}")
+                
+                return {
+                    "status": "joined",
+                    "meeting_id": meeting_id,
+                    "bot_id": response.bot_id,
+                    "twin_id": twin_id
+                }
+            else:
+                # Update meeting status back to scheduled if join failed
+                meeting.status = "scheduled"
+                db.commit()
+                
+                logger.error(f"Failed to auto-join meeting {meeting_id}: {response.error_details}")
+                return {
+                    "status": "failed",
+                    "meeting_id": meeting_id,
+                    "error": response.error_details
+                }
+                
+            db.close()
+            
+        except Exception as e:
+            logger.error(f"Auto-join failed for meeting {meeting_id}: {str(e)}")
+            
+            # Reset meeting status on error
+            try:
+                db = SessionLocal()
+                meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+                if meeting:
+                    meeting.status = "scheduled"
+                    db.commit()
+                db.close()
+            except Exception as db_error:
+                logger.error(f"Failed to reset meeting status: {str(db_error)}")
+            
+            return {
+                "status": "failed",
+                "meeting_id": meeting_id,
+                "error": str(e)
+            }
+    
+    # Run the async function
+    return asyncio.run(_join_meeting_async())
 
 
 @celery_app.task
@@ -170,3 +336,117 @@ def stop_meeting_bot(bot_id: str) -> bool:
     except Exception as e:
         logger.error(f"Failed to stop bot {bot_id}: {str(e)}")
         return False
+
+
+@celery_app.task
+def cleanup_old_meetings():
+    """
+    Clean up old completed meetings and update their status
+    Runs daily to maintain database hygiene
+    """
+    logger.info("Running meeting cleanup task...")
+    
+    try:
+        db = SessionLocal()
+        
+        # Update meetings that are past their end time but still marked as in_progress
+        cutoff_time = datetime.utcnow() - timedelta(hours=6)  # 6 hours buffer
+        
+        old_meetings = db.query(Meeting).filter(
+            and_(
+                Meeting.status == "in_progress",
+                Meeting.scheduled_time < cutoff_time
+            )
+        ).all()
+        
+        for meeting in old_meetings:
+            # Calculate estimated end time
+            estimated_end = meeting.scheduled_time + timedelta(minutes=meeting.duration_minutes)
+            if datetime.utcnow() > estimated_end + timedelta(hours=1):  # 1 hour buffer
+                meeting.status = "completed"
+                logger.info(f"Marked meeting {meeting.id} as completed")
+        
+        db.commit()
+        db.close()
+        
+        logger.info(f"Cleanup completed. Updated {len(old_meetings)} meetings.")
+        
+    except Exception as e:
+        logger.error(f"Meeting cleanup error: {str(e)}")
+
+
+def get_upcoming_auto_join_meetings(user_id: int = None) -> List[Meeting]:
+    """
+    Get meetings that are scheduled for auto-join in the next few hours
+    Useful for dashboard/status displays
+    """
+    try:
+        db = SessionLocal()
+        
+        now = datetime.utcnow()
+        next_hour = now + timedelta(hours=2)
+        
+        query = db.query(Meeting).filter(
+            and_(
+                Meeting.auto_join == True,
+                Meeting.status == "scheduled",
+                Meeting.scheduled_time >= now,
+                Meeting.scheduled_time <= next_hour,
+                Meeting.digital_twin_id.isnot(None)
+            )
+        )
+        
+        if user_id:
+            query = query.filter(Meeting.user_id == user_id)
+        
+        meetings = query.order_by(Meeting.scheduled_time).all()
+        db.close()
+        
+        return meetings
+        
+    except Exception as e:
+        logger.error(f"Error getting upcoming auto-join meetings: {str(e)}")
+        return []
+
+
+def force_join_meeting(meeting_id: int) -> dict:
+    """
+    Manually trigger auto-join for a specific meeting
+    Useful for testing or manual intervention
+    """
+    try:
+        db = SessionLocal()
+        
+        meeting = db.query(Meeting).filter(Meeting.id == meeting_id).first()
+        if not meeting:
+            return {"status": "failed", "error": "Meeting not found"}
+        
+        if not meeting.auto_join:
+            return {"status": "failed", "error": "Auto-join not enabled for this meeting"}
+        
+        if not meeting.digital_twin_id:
+            return {"status": "failed", "error": "No digital twin assigned to this meeting"}
+        
+        # Update status to prevent scheduler from picking it up
+        meeting.status = "joining"
+        db.commit()
+        db.close()
+        
+        # Trigger the join task
+        task = join_meeting_auto.delay(
+            meeting.id,
+            meeting.digital_twin_id,
+            meeting.meeting_url,
+            meeting.platform,
+            meeting.user_id
+        )
+        
+        return {
+            "status": "triggered",
+            "task_id": task.id,
+            "meeting_id": meeting_id
+        }
+        
+    except Exception as e:
+        logger.error(f"Force join failed for meeting {meeting_id}: {str(e)}")
+        return {"status": "failed", "error": str(e)}

--- a/simple_auto_join.py
+++ b/simple_auto_join.py
@@ -1,0 +1,218 @@
+"""
+Simple auto-join scheduler without Redis/Celery
+This is a lightweight alternative for testing auto-join functionality
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import List
+from sqlalchemy.orm import Session
+from sqlalchemy import and_
+
+from app.core.database import SessionLocal
+from app.models.meeting import Meeting
+from app.models.bot import Bot
+from app.models.user import User
+from app.schemas.meeting import MeetingJoinRequest
+from app.core.config import settings
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Pakistan/Karachi timezone (UTC+5)
+PAKISTAN_TZ = timezone(timedelta(hours=5))
+
+class SimpleAutoJoinScheduler:
+    """Simple scheduler that runs in a loop without Celery"""
+    
+    def __init__(self):
+        self.running = False
+        
+    async def check_and_join_meetings(self):
+        """Check for meetings that need auto-joining and join them (Pakistan time logic)"""
+        try:
+            db = SessionLocal()
+            # Get current Pakistan time (naive)
+            pakistan_now = datetime.now().replace(second=0, microsecond=0)
+            join_window_start = pakistan_now
+            join_window_end = pakistan_now + timedelta(minutes=settings.AUTO_JOIN_ADVANCE_MINUTES)
+
+            logger.info(f"🇵🇰 Pakistan time: {pakistan_now.strftime('%Y-%m-%d %H:%M:%S')} (PKT)")
+            logger.info(f"🔍 Checking for meetings between {join_window_start.strftime('%H:%M:%S')} and {join_window_end.strftime('%H:%M:%S')} PKT")
+
+            # Debug: Show all auto-join enabled meetings
+            all_auto_join_meetings = db.query(Meeting).filter(
+                Meeting.auto_join == True
+            ).all()
+
+            logger.info(f"📊 Total auto-join enabled meetings in DB: {len(all_auto_join_meetings)}")
+            for meeting in all_auto_join_meetings:
+                # Treat scheduled_time as Pakistan time (naive)
+                logger.info(f"  📅 Meeting {meeting.id}: '{meeting.title}' at {meeting.scheduled_time.strftime('%Y-%m-%d %H:%M:%S')} PKT (Pakistan time)")
+                logger.info(f"      Status: {meeting.status}, Digital Twin ID: {meeting.digital_twin_id}")
+
+            # Find meetings that need auto-joining (Pakistan time logic)
+            meetings_to_join = db.query(Meeting).filter(
+                and_(
+                    Meeting.auto_join == True,
+                    Meeting.status == "scheduled",
+                    Meeting.scheduled_time >= join_window_start,
+                    Meeting.scheduled_time <= join_window_end,
+                    Meeting.digital_twin_id.isnot(None)
+                )
+            ).all()
+
+            logger.info(f"🎯 Found {len(meetings_to_join)} meetings ready to auto-join")
+            for meeting in meetings_to_join:
+                try:
+                    await self.join_meeting(meeting, db)
+                except Exception as e:
+                    logger.error(f"Failed to auto-join meeting {meeting.id}: {str(e)}")
+            db.close()
+        except Exception as e:
+            logger.error(f"Auto-join check error: {str(e)}")
+    
+    async def join_meeting(self, meeting: Meeting, db: Session):
+        """Join a single meeting using the FastAPI endpoint"""
+        try:
+            # Update meeting status to prevent duplicate joins
+            meeting.status = "joining"
+            db.commit()
+            
+            # Get user details for bot naming and profile picture
+            user = db.query(User).filter(User.id == meeting.user_id).first()
+            # Use custom bot name if set, otherwise use default
+            bot_name = user.bot_name if user and user.bot_name else "Digital Twin Bot"
+            profile_picture = user.profile_picture if user and user.profile_picture else None
+            
+            # Create the join request payload (matching manual endpoint structure)
+            join_request_data = {
+                "meeting_url": meeting.meeting_url,
+                "bot_name": bot_name,
+                "enable_realtime_processing": False,
+                "recording_config": {}  # Add this to match manual endpoint structure
+            }
+            
+            # Add profile picture if available
+            if profile_picture:
+                join_request_data["profile_picture"] = profile_picture
+            
+            logger.info(f"Attempting to join meeting {meeting.id}: {meeting.title}")
+            
+            # Call the recall service directly for auto-join (internal process)
+            try:
+                logger.info(f"🔌 Calling Recall service for meeting URL: {meeting.meeting_url}")
+                
+                # Create the join request with user's profile settings
+                join_request = MeetingJoinRequest(
+                    meeting_url=meeting.meeting_url,
+                    bot_name=bot_name,
+                    profile_picture=profile_picture,
+                    enable_realtime_processing=False,
+                    recording_config={}
+                )
+                
+                # Import and use recall service
+                from app.services.recall_service import recall_service
+                response = await recall_service.join_meeting(join_request)
+                
+                logger.info(f"📡 Recall service response: success={response.success}")
+                
+                # Check if response is successful
+                if response.success and response.bot_id:
+                    # Update meeting status
+                    meeting.status = "in_progress"
+                    
+                    # Create or update bot record with correct user_id
+                    existing_bot = db.query(Bot).filter(Bot.bot_id == response.bot_id).first()
+                    if not existing_bot:
+                        new_bot = Bot(
+                            bot_id=response.bot_id,
+                            user_id=meeting.user_id,  # Use meeting's user_id (correct user)
+                            bot_name=bot_name,
+                            platform=meeting.platform,
+                            meeting_id=meeting.id
+                        )
+                        db.add(new_bot)
+                    else:
+                        existing_bot.meeting_id = meeting.id
+                        existing_bot.platform = meeting.platform
+                        existing_bot.user_id = meeting.user_id  # Ensure correct user_id
+                    
+                    db.commit()
+                    logger.info(f"✅ Successfully auto-joined meeting {meeting.id} with bot {response.bot_id}")
+                    
+                else:
+                    # Handle failed response
+                    error_msg = response.message if hasattr(response, 'message') else 'Unknown error'
+                    
+                    # Update meeting status back to scheduled if join failed
+                    meeting.status = "scheduled"
+                    db.commit()
+                    
+                    logger.error(f"❌ Failed to auto-join meeting {meeting.id}: {error_msg}")
+                    
+            except Exception as api_error:
+                # Handle API call exceptions
+                meeting.status = "scheduled"
+                db.commit()
+                logger.error(f"❌ Recall service error for meeting {meeting.id}: {str(api_error)}")
+                
+                # Log more details about the error
+                if "validation" in str(api_error).lower():
+                    logger.error(f"   Validation error - check Recall API credentials and meeting URL format")
+                elif "connection" in str(api_error).lower():
+                    logger.error(f"   Connection error - check internet connection and Recall API status")
+                else:
+                    logger.error(f"   Unexpected error: {type(api_error).__name__}")
+            
+        except Exception as e:
+            logger.error(f"❌ Auto-join failed for meeting {meeting.id}: {str(e)}")
+            
+            # Reset meeting status on error
+            meeting.status = "scheduled"
+            db.commit()
+    
+    async def run(self):
+        """Main scheduler loop"""
+        self.running = True
+        pakistan_now = datetime.now(PAKISTAN_TZ)
+        logger.info("🤖 Simple Auto-Join Scheduler Started")
+        logger.info(f"🇵🇰 Pakistan Time: {pakistan_now.strftime('%Y-%m-%d %H:%M:%S')} (UTC+5)")
+        logger.info(f"⏰ Checking every {settings.AUTO_JOIN_CHECK_INTERVAL} seconds")
+        logger.info(f"🎯 Joining meetings {settings.AUTO_JOIN_ADVANCE_MINUTES} minutes before start time")
+        
+        try:
+            while self.running:
+                await self.check_and_join_meetings()
+                await asyncio.sleep(settings.AUTO_JOIN_CHECK_INTERVAL)
+                
+        except KeyboardInterrupt:
+            logger.info("🛑 Scheduler stopped by user")
+        except Exception as e:
+            logger.error(f"💥 Scheduler error: {str(e)}")
+        finally:
+            self.running = False
+    
+    def stop(self):
+        """Stop the scheduler"""
+        self.running = False
+
+async def main():
+    """Run the simple auto-join scheduler"""
+    scheduler = SimpleAutoJoinScheduler()
+    
+    try:
+        await scheduler.run()
+    except KeyboardInterrupt:
+        print("\n🛑 Stopping auto-join scheduler...")
+        scheduler.stop()
+
+if __name__ == "__main__":
+    print("🚀 Starting Simple Auto-Join Scheduler (Redis-free version)")
+    print("📝 This version doesn't require Redis/Celery")
+    print("⚠️  For production, use the full Celery version with Redis")
+    print("\nPress Ctrl+C to stop\n")
+    
+    asyncio.run(main())


### PR DESCRIPTION
- Added endpoints for managing auto-join settings, including getting upcoming meetings, forcing a join, and toggling auto-join.
- Integrated auto-join logic into the meeting creation process, allowing users to automatically join meetings with their digital twin.
- Created a Celery beat schedule for periodic auto-join checks and cleanup of old meetings.
- Enhanced user profile management to include digital twin settings such as bot name and profile picture.
- Updated Recall API service to support joining meetings with custom bot names and profile pictures.
- Introduced a simple auto-join scheduler for testing without Redis/Celery.
- Improved error handling and logging throughout the auto-join process.